### PR TITLE
Add the Current Computer Time as a HUD Component

### DIFF
--- a/HudComponents/HudComponent.cs
+++ b/HudComponents/HudComponent.cs
@@ -12,6 +12,8 @@ namespace CKHud.HudComponents {
                     return new CenterDistanceHudComponent();
                 case "DPS":
                     return new DPSHudComponent();
+                case "LocalComputerTime":
+                    return new LocalComputerTimeComponent();
                 default:
                     return null;
             }

--- a/HudComponents/LocalComputerTime.cs
+++ b/HudComponents/LocalComputerTime.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CKHud.HudComponents {
+    public class LocalComputerTimeComponent : HudComponent {
+        public override string GetString() {
+            return DateTime.Now.ToShortTimeString();
+        }
+    }
+}

--- a/HudComponents/LocalComputerTime.cs.meta
+++ b/HudComponents/LocalComputerTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad9586fc2b2bb664398d2b442f97cb74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HudManager.cs
+++ b/HudManager.cs
@@ -18,7 +18,7 @@ namespace CKHud {
 		public string DEFAULT_COMPONENTS = "FPS;Position;CenterDistance;DPS;LocalComputerTime";
 
 
-        private bool foundText = false;
+		private bool foundText = false;
 
 		void Awake() {
 			if (instance == null) {

--- a/HudManager.cs
+++ b/HudManager.cs
@@ -14,8 +14,11 @@ namespace CKHud {
 		public bool compactMode = false;
 		
 		public List<HudRow> hudRows = new List<HudRow>();
-		
-		private bool foundText = false;
+
+		public string DEFAULT_COMPONENTS = "FPS;Position;CenterDistance;DPS;LocalComputerTime";
+
+
+        private bool foundText = false;
 
 		void Awake() {
 			if (instance == null) {
@@ -83,7 +86,7 @@ namespace CKHud {
 
 		void LoadLayoutConfig() {
 			string componentLayout = "";
-			ConfigSystem.GetString("Components", "Layout", ref componentLayout, "FPS;Position;CenterDistance;DPS");
+			ConfigSystem.GetString("Components", "Layout", ref componentLayout, DEFAULT_COMPONENTS);
 			string[] rowStrings = componentLayout.Replace(" ", "").Split(';');
 			int rowsUsed = (int)Mathf.Min(rowStrings.Length, hudRows.Count);
 			


### PR DESCRIPTION
Worked locally 🎉 

So I don't know if the Component should be named "LocalComputerTime" maybe its too long or maybe we need some kind of better Name for that, what do you think?

Also I extracted the default components list so that its a bit easier to find in Code ( this will be probably changed at some point anyway, once there are more Components/ Settings)