### PR TITLE
Spawn Cell & other stuff

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = tab
+csharp_new_line_before_open_brace = false

--- a/CKHudMod.cs
+++ b/CKHudMod.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Runtime.CompilerServices;
 using PugMod;
 using UnityEngine;
 
@@ -16,8 +17,12 @@ namespace CKHud {
 		public static void Log(object message) {
 			Debug.Log(MOD_NAME + ": " + message.ToString());
 		}
-		
-		public void EarlyInit() {
+
+        public static void LogMethod(object message, [CallerMemberName] string callerMethod = "") {
+            Debug.Log($"{MOD_NAME} [${callerMethod}]: {message}");
+        }
+
+        public void EarlyInit() {
 			modInfo = GetModInfo();
 
 			if (modInfo != null) {

--- a/ConfigSystem.cs
+++ b/ConfigSystem.cs
@@ -16,15 +16,18 @@ namespace CKHud {
         }
         
         public static bool GetFloat(string section, string key, ref float value, float defaultValue) {
-            if (API.Config.TryGet(CKHudMod.MOD_ID, section, key, out string valueString)) {
-                if (float.TryParse(valueString, out float output)) {
+            if (API.Config.TryGet<float>(CKHudMod.MOD_ID, section, key, out float configuredFloatValue)) {
+				value = configuredFloatValue;
+
+				return true;
+               /* if (float.TryParse(valueString, Local, out float output)) {
                     value = output;
                     return true;
                 }
                 else {
                     CKHudMod.Log("The config value entered for \"" + section + "/" + key + "\" is not the right type (it should be a number).");
                     return false;
-                }
+                }*/
             }
             else {
                 API.Config.Set(CKHudMod.MOD_ID, section, key, defaultValue);

--- a/HudComponents/HudComponent.cs
+++ b/HudComponents/HudComponent.cs
@@ -1,26 +1,5 @@
 namespace CKHud.HudComponents {
     public class HudComponent {
-        public static HudComponent Parse(string str) {
-            switch (str) {
-                case "FPS":
-                    return new FPSHudComponent();
-                case "FPSCap":
-                    return new FPSCapHudComponent();
-                case "Position":
-                    return new PositionHudComponent();
-                case "CenterDistance":
-                    return new CenterDistanceHudComponent();
-                case "DPS":
-                    return new DPSHudComponent();
-                case "LocalComputerTime":
-                    return new LocalComputerTimeHudComponent();
-                case "MaxDPS":
-                    return new MaxDPSHudComponent();
-                default:
-                    return null;
-            }
-        }
-        
         public virtual string GetString() {
             return "";
         }

--- a/HudComponents/HudComponentsRegistry.cs
+++ b/HudComponents/HudComponentsRegistry.cs
@@ -1,0 +1,51 @@
+﻿using CKHud;
+using CKHud.HudComponents;
+using System;
+using System.Collections.Generic;
+
+namespace Assets.CKHud.HudComponents {
+	public static class HudComponentsRegistry {
+		private static Dictionary<string, Type> _registry = new Dictionary<string, Type> {
+			{"FPS",                 typeof(FPSHudComponent)},
+			{"FPSCap",              typeof(FPSCapHudComponent) },
+
+			{"Position",            typeof(PositionHudComponent)},
+			{"CenterDistance",      typeof(CenterDistanceHudComponent)},
+
+			{"DPS",                 typeof(DPSHudComponent)},
+			{"MaxDPS",              typeof(MaxDPSHudComponent)},
+
+			{"LocalComputerTime",   typeof(LocalComputerTimeHudComponent)},
+
+			{"SpawnCell",			typeof(SpawnCellHudComponent)}
+		};
+
+		public static HudComponent GetHudComponentByType(string type) {
+			if (_registry.ContainsKey(type)) {
+				return Activator.CreateInstance(_registry[type]) as HudComponent;
+			}
+
+			return null;
+		}
+
+		public static void RegisterHudComponent(string type, Type hudComponent) {
+			if (string.IsNullOrEmpty(type)) {
+				CKHudMod.LogMethod("empty type param - Skipping Register");
+				return;
+			}
+
+			if (_registry.ContainsKey(type)) {
+
+				CKHudMod.LogMethod($"{type} already registered - Skipping Register");
+				return;
+			}
+
+			if (!hudComponent.IsSubclassOf(typeof(HudComponent))) {
+				CKHudMod.LogMethod($"{type} not a subclass of HudComponent - Skipping Register");
+				return;
+			}
+
+			_registry[type] = hudComponent;
+		}
+	}
+}

--- a/HudComponents/HudComponentsRegistry.cs.meta
+++ b/HudComponents/HudComponentsRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d41ea4494e2cae54d95d603e0f13bf91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HudComponents/SpawnCellHudComponent.cs
+++ b/HudComponents/SpawnCellHudComponent.cs
@@ -18,7 +18,8 @@ namespace CKHud.HudComponents {
 
 			// Spawn [Cell X | Cell Y] <PosX in C | PosY in C>s
 
-			return $"Cell [{spawnCellX:00##}; {spawnCellY:00##}]  <{posInCellX:00##} | {posInCellY:00##}>";
+			return $"Cell {spawnCellX:00}/{spawnCellY:00}  Pos {posInCellX:00}/{posInCellY:00}";
 		}
     }
 }
+ 

--- a/HudComponents/SpawnCellHudComponent.cs
+++ b/HudComponents/SpawnCellHudComponent.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+
+namespace CKHud.HudComponents {
+    public class SpawnCellHudComponent : HudComponent {
+		private static int SPAWN_CELL_SIZE = 16;
+
+		public override string GetString() {
+			Vector3 playerPosition = Manager.main.player.WorldPosition;
+
+			// Math.Floor because even at Pos 8 / 16 = 0.5 should still be 0
+			var spawnCellX = Math.Floor(playerPosition.x / SPAWN_CELL_SIZE);
+			// Using Y for less headache, internally Z because of the 3D
+			var spawnCellY = Math.Floor(playerPosition.z / SPAWN_CELL_SIZE);
+
+			var posInCellX = Math.Abs(playerPosition.x) % SPAWN_CELL_SIZE;
+			var posInCellY = Math.Abs(playerPosition.z) % SPAWN_CELL_SIZE;
+
+			// Spawn [Cell X | Cell Y] <PosX in C | PosY in C>s
+
+			return $"Cell [{spawnCellX:00##}; {spawnCellY:00##}]  <{posInCellX:00##} | {posInCellY:00##}>";
+		}
+    }
+}

--- a/HudComponents/SpawnCellHudComponent.cs.meta
+++ b/HudComponents/SpawnCellHudComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b147183b76ca5c439d62e8dc59e2806
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HudManager.cs
+++ b/HudManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using CKHud.HudComponents;
+using Assets.CKHud.HudComponents;
 
 namespace CKHud {
 	public class HudManager : MonoBehaviour {
@@ -97,7 +98,7 @@ namespace CKHud {
 				string[] componentStrings = rowStrings[i].Split(',');
 				
 				foreach (string componentString in componentStrings) {
-					HudComponent component = HudComponent.Parse(componentString);
+					HudComponent component = HudComponentsRegistry.GetHudComponentByType(componentString);
 
 					if (component != null) {
 						hudRows[i].components.Add(component);

--- a/HudManager.cs
+++ b/HudManager.cs
@@ -58,8 +58,11 @@ namespace CKHud {
 				Transform mapUITransform = FindMapUI(ingameUI);
 
 				mapUI = mapUITransform.GetComponent<MapUI>();
-				
-				InitHudRowsText(ingameUI);
+
+				GameObject ckHudHolder = new GameObject("CKHudUI");
+				ckHudHolder.transform.parent = ingameUI;
+
+				InitHudRowsText(ckHudHolder.transform);
 				
 				CKHudMod.Log("Created text objects.");
 				
@@ -159,8 +162,7 @@ namespace CKHud {
 		}
 
 		void CreateHudRows(int amount) {
-			float textYPosition = startHudPosition;
-			for (int i = 0; i < amount; i++, textYPosition += hudLineStep) {
+			for (int i = 0; i < amount; i++) {
 				hudRows.Add(new HudRow());
 			}
 		}


### PR DESCRIPTION
This contains bit more than I expected but here is a list:

- `.editorconfig` since I don't wanted to create files with a different format that you are using, I tried to set atleast the 2 things that I saw. Tab Spacing and Bracket at the end of the line, you can extend this from Visual Studio itself so that all other code will be formatted the way you want it
- Added a new `LogMethod` which gets the Callers Method Name inserted by CompileTime for an easier way to pinpoint a Log Message
- Fixed the Float Loading/Parsing Issue that stopped the Mod for non-english computers
- First Step into being able to use CKHud as a mod dependency, I extracted the HUDComponent List to a Registry (can revert again if you want), just thought this would be needed soon anyway
- Added a parent GameObject for all PugTexts, there is still an issue that these GameObjects are created twice, I couldn't figure out yet why


And then the Actual Reason of this PR - the Spawn Cell Component :tada: 